### PR TITLE
Add a license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, Xylar Asay-Davis
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [
   { name = "Xylar Asay-Davis" }
 ]
-license = { text = "BSD-3-Clause" }
+license = { file = "LICENSE" }
 requires-python = ">=3.10"
 keywords = ["config", "configparser", "layered", "provenance", "numpy", "safe-eval"]
 classifiers = [
@@ -42,6 +42,12 @@ docs = [
 [tool.setuptools]
 packages = ["layeredconfig"]
 include-package-data = true
+license-files = [
+  "LICENSE",
+  "LICENSE.*",
+  "COPYING*",
+  "NOTICE*",
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "layeredconfig.version.__version__"}


### PR DESCRIPTION
This pull request updates the project's licensing setup to ensure compliance and clarity regarding the BSD 3-Clause License. The main changes involve adding the full license text and updating configuration files to reference it properly.

**Licensing updates:**

* Added a `LICENSE` file containing the full BSD 3-Clause License text.
* Updated `pyproject.toml` to reference the license via the new `LICENSE` file instead of inline text.
* Configured `pyproject.toml` to include `LICENSE` and related files in package distributions through the `license-files` setting.