### PR TITLE
Update publish workflow for pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,14 +50,18 @@ jobs:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
       # Publish to PyPI on release/tag, or manual dispatch to PyPI
       - name: Publish to PyPI
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.repository == 'pypi')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          # Use Trusted Publishing via OIDC (no username/password). Ensure TP is configured
+          # for this repo/workflow in PyPI project settings. See:
+          # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+          skip-existing: true
+          attestations: true
 
 # Usage:
 # - Set repository secrets PYPI_API_TOKEN and TEST_PYPI_API_TOKEN (API tokens starting with 'pypi-').


### PR DESCRIPTION
This pull request updates the PyPI publishing workflow in `.github/workflows/publish.yml` to improve the publishing process and security. The main changes are the addition of the `skip-existing` and `attestations` options, and a move towards using Trusted Publishing via OIDC for PyPI releases.

Publishing workflow improvements:

* Added the `skip-existing: true` option to both TestPyPI and PyPI publishing steps to avoid errors if a version already exists.
* Enabled `attestations: true` for the PyPI publishing step to generate provenance attestations for published packages.
* Updated the PyPI publishing step to use Trusted Publishing via OIDC, removing the need for a username and password and improving security.