### PR TITLE
Change behavior of `backend` parameter to `getexpression()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.2.0] - 2025-09-19
+### Added
+- `Tranche.getnumpy()` convenience helper for NumPy-enabled expressions.
+
+### Changed
+- `getexpression()` now accepts `backend=None` (default). It auto-selects
+  `safe` when `allow_numpy=True` and `literal` otherwise.
+- Removed implicit literal->safe fallback/print; behavior is now deterministic
+  based on arguments.
+
+### Notes
+- This is an intentional minor version bump due to a public API signature
+  change (`backend` can now be `None`). Existing code that passed an explicit
+  backend string continues to work unchanged.
+
 ## [0.1.1] - 2025-09-12
 ### Changed
 - Publishing workflow for PyPI updated: publish on GitHub Release instead of on tag.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ config.add_user_config("user.cfg")
 # Simple values
 value = config.get("core", "option")
 
-# Expression (literal)
-points = config.getexpression("plot", "ticks", backend="literal")
+# Expression (literal backend chosen automatically)
+points = config.getexpression("plot", "ticks")
 
-# Expression (safe with numpy)
-arr = config.getexpression("plot", "bins", backend="safe", allow_numpy=True)
+# NumPy expression (auto-selects safe backend because allow_numpy=True)
+arr = config.getexpression("plot", "bins", allow_numpy=True)
+
+# Or via convenience helper
+arr2 = config.getnumpy("plot", "bins")
 
 # Provenance
 info = config.explain("plot", "bins")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,13 +38,20 @@ lower.append(higher)  # entries from 'higher' win
 
 ## Safe expressions
 
-To parse list/tuple/dict values, or evaluate expressions using a safe AST evaluator:
+To parse list/tuple/dict values, or evaluate expressions:
 
 ```python
-cfg.getexpression('calc', 'values', backend='safe')
+# Literal-only (numbers, strings, containers)
+vals = cfg.getexpression('calc', 'values')
+
+# NumPy-enabled expression auto-selects safe backend
+grid = cfg.getexpression('grid', 'levels', allow_numpy=True)
+
+# Or use the helper for NumPy
+grid2 = cfg.getnumpy('grid', 'levels')
 ```
 
-Register custom callables for the safe backend:
+Register custom callables for the safe backend (available when backend resolves to 'safe'):
 
 ```python
 import math

--- a/tests/test_tranche_numpy_math.py
+++ b/tests/test_tranche_numpy_math.py
@@ -112,3 +112,43 @@ def test_safe_eval_with_numpy_enabled(tmp_path: Path) -> None:
     assert np.allclose(b, np.linspace(0, 1, 5))
     assert c.__class__.__name__ == "ndarray"
     assert np.array_equal(c, np.array([1, 2, 3]))
+
+
+def test_numpy_auto_backend(tmp_path: Path) -> None:
+    np = pytest.importorskip("numpy")
+
+    cfg_path = write_tmp_cfg(
+        tmp_path,
+        "auto_np.cfg",
+        """
+        [expr]
+        grid = numpy.linspace(0, -4, 5)
+        """,
+    )
+
+    cfg = Tranche()
+    cfg.add_from_file(cfg_path)
+
+    # backend left as default (None internally), allow_numpy triggers safe
+    # backend
+    grid = cfg.getexpression("expr", "grid", allow_numpy=True)
+    assert np.allclose(grid, np.linspace(0, -4, 5))
+
+
+def test_getnumpy_helper(tmp_path: Path) -> None:
+    np = pytest.importorskip("numpy")
+
+    cfg_path = write_tmp_cfg(
+        tmp_path,
+        "helper_np.cfg",
+        """
+        [expr]
+        arr = np.arange(4)
+        """,
+    )
+
+    cfg = Tranche()
+    cfg.add_from_file(cfg_path)
+
+    arr = cfg.getnumpy("expr", "arr")
+    assert np.array_equal(arr, np.arange(4))

--- a/tranche/version.py
+++ b/tranche/version.py
@@ -8,4 +8,4 @@ __all__ = ["__version__"]
 
 # Update this value for releases; pre-releases can use semantic versions
 # like "0.2.0rc1". The packaging config reads this attribute.
-__version__ = "0.1.1"
+__version__ = "0.2.0"


### PR DESCRIPTION
This pull request introduces a minor version bump to 0.2.0 with a focus on improving expression evaluation flexibility and convenience, especially for NumPy-enabled expressions. The core changes include a new `getnumpy()` helper for NumPy expressions, adaptive backend selection in `getexpression()`, and updated documentation and tests to reflect these enhancements.

**API Enhancements:**

* Added a `getnumpy()` convenience helper method to the `Tranche` class for evaluating NumPy-enabled expressions, which internally sets `allow_numpy=True` and adapts backend selection.
* Modified `getexpression()` to accept `backend=None` (now the default), which auto-selects the backend: `"safe"` when `allow_numpy=True`, otherwise `"literal"`. This makes the API more intuitive for users working with NumPy expressions. [[1]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8L457-R457) [[2]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8L480-R482) [[3]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8R491-R494)

**Behavioral Changes:**

* Removed implicit fallback from `"literal"` to `"safe"` backend and related print statements, making backend selection deterministic based on arguments.

**Documentation Updates:**

* Updated `README.md` and `docs/getting-started.md` to demonstrate the new `getnumpy()` helper and the improved backend selection logic for expression evaluation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R54) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L41-R54)

**Testing:**

* Added new tests for the auto-backend selection with NumPy expressions and for the `getnumpy()` helper to ensure correct behavior.

**Versioning:**

* Bumped the project version to `0.2.0` and updated the changelog to reflect these changes and the public API signature update. [[1]](diffhunk://#diff-bbd38e1ca0b47b9b7663f8610b47e1c956bc6925b2d938860b2d489b0c4fbed8L11-R11) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R21)