### PR TITLE
More fixes to PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,11 +62,17 @@ jobs:
       id-token: write  # for OIDC trusted publishing
       contents: read
     steps:
+      - name: Checkout (for version introspection)
+        uses: actions/checkout@v4
       - name: Download distributions
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
+      - name: Set up Python (for optional version check/debug)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -85,11 +91,17 @@ jobs:
       id-token: write  # for OIDC trusted publishing
       contents: read
     steps:
+      - name: Checkout (for version verification)
+        uses: actions/checkout@v4
       - name: Download distributions
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
+      - name: Set up Python (for version verification)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Verify tag matches version
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,11 @@ jobs:
 
   publish-to-testpypi:
     name: Publish to TestPyPI
-    # Only publish to TestPyPI for pushes to main (not for pull requests / tags directly)
-    if: github.ref == 'refs/heads/main'
+    # Trigger only for pre-release tags (rc, a, b, dev). Final releases (no pre-release marker) skip this.
+    # You can also run this manually via workflow_dispatch for ad‑hoc testing without tagging.
+    if: |
+      (startsWith(github.ref, 'refs/tags/') && (contains(github.ref, 'rc') || contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'dev'))) ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     needs: [ build ]
     runs-on: ubuntu-latest
     environment:
@@ -73,6 +76,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Verify tag matches version (pre-release)
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          FILE_VERSION=$(python -c "import tranche.version as v; print(v.__version__)")
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) != package version ($FILE_VERSION)" >&2
+            exit 1
+          fi
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -80,8 +91,9 @@ jobs:
 
   publish-to-pypi:
     name: Publish to PyPI
-    # Run on any tag (semantic versions used directly, no leading 'v')
-    if: startsWith(github.ref, 'refs/tags/')
+    # Run only on final release tags: tagged versions without pre-release markers.
+    # Ensures pre-releases never hit PyPI until promoted by tagging a final version.
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') && !contains(github.ref, 'a') && !contains(github.ref, 'b') && !contains(github.ref, 'dev')
     needs: [ build ]
     runs-on: ubuntu-latest
     environment:

--- a/tranche/version.py
+++ b/tranche/version.py
@@ -8,4 +8,4 @@ __all__ = ["__version__"]
 
 # Update this value for releases; pre-releases can use semantic versions
 # like "0.2.0rc1". The packaging config reads this attribute.
-__version__ = "0.2.2rc1"
+__version__ = "0.2.2rc2"


### PR DESCRIPTION
This pull request updates the publishing workflow in `.github/workflows/publish.yml` to improve the release process for both pre-releases and final releases. The main changes ensure that pre-releases are only published to TestPyPI, final releases are only published to PyPI, and that the version in the tag matches the package version before publishing. Additional steps have been added for version verification and debugging.

**Release workflow improvements:**

* Updated the `publish-to-testpypi` job to trigger only for pre-release tags (`rc`, `a`, `b`, `dev`) or via manual dispatch on `main`, preventing accidental publication of final releases to TestPyPI.
* Updated the `publish-to-pypi` job to trigger only for final release tags (tags without pre-release markers), ensuring that pre-releases are never published to PyPI.

**Version verification enhancements:**

* Added steps to both `publish-to-testpypi` and `publish-to-pypi` jobs to check out the repository, set up Python, and verify that the tag version matches the package version before publishing. This prevents mismatched versions from being published. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R68-R96) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R106-R116)