### PR TITLE
Add `kwargs` to `Tranche` `get*()` methods

### DIFF
--- a/tranche/section.py
+++ b/tranche/section.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from configparser import SectionProxy
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar
 
 # Import Tranche only for type checking to avoid circular imports at runtime
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -46,8 +46,8 @@ class Section:
     def getlist(
         self,
         option: str,
-        dtype: Callable[[str], T] | None = None,
-    ) -> list[T]:
+        **kwargs: Any,
+    ) -> Any:
         """
         Get an option value parsed as a list.
 
@@ -55,24 +55,22 @@ class Section:
         ----------
         option : str
             Option name within this section.
-        dtype : Callable[[str], T], optional
-            Converter applied to each item. Defaults to ``str``.
+        **kwargs : Any
+            Additional keyword arguments forwarded to
+            :meth:`tranche.Tranche.getlist`.
 
         Returns
         -------
-        list of T
-            Parsed list with elements converted by ``dtype``.
+        Any
+            Parsed list value as returned by
+            :meth:`tranche.Tranche.getlist`.
         """
-        if dtype is None:
-            dtype = cast(Callable[[str], T], str)
-        return self._tranche.getlist(self._name, option, dtype=dtype)
+        return self._tranche.getlist(self._name, option, **kwargs)
 
     def getexpression(
         self,
         option: str,
-        dtype: type | None = None,
-        backend: str | None = None,
-        allow_numpy: bool = False,
+        **kwargs: Any,
     ) -> Any:
         """
         Evaluate an option as a Python expression safely.
@@ -81,14 +79,9 @@ class Section:
         ----------
         option : str
             Option name within this section.
-        dtype : type, optional
-            If provided, cast list/tuple elements or dict values.
-        backend : {"literal", "safe"} or None, optional
-            Evaluation backend. ``None`` chooses ``"safe"`` when
-            ``allow_numpy`` is True, otherwise ``"literal"``.
-        allow_numpy : bool, optional
-            If True and using the "safe" backend, expose limited numpy
-            functions under ``np``/``numpy``.
+        **kwargs : Any
+            Additional keyword arguments forwarded to
+            :meth:`tranche.Tranche.getexpression`.
 
         Returns
         -------
@@ -98,16 +91,13 @@ class Section:
         return self._tranche.getexpression(
             self._name,
             option,
-            dtype=dtype,
-            backend=backend,
-            allow_numpy=allow_numpy,
+            **kwargs,
         )
 
     def getnumpy(
         self,
         option: str,
-        dtype: type | None = None,
-        backend: str | None = None,
+        **kwargs: Any,
     ) -> Any:
         """
         Evaluate an expression with NumPy enabled.
@@ -118,17 +108,20 @@ class Section:
         ----------
         option : str
             Option name within this section.
-        dtype : type, optional
-            If provided, cast list/tuple elements or dict values.
-        backend : {"literal", "safe"} or None, optional
-            Backend override. ``None`` chooses ``"safe"``.
+        **kwargs : Any
+            Additional keyword arguments forwarded to
+            :meth:`tranche.Tranche.getnumpy`.
 
         Returns
         -------
         Any
             Result of the evaluated expression, optionally cast.
         """
-        return self._tranche.getnumpy(self._name, option, dtype=dtype, backend=backend)
+        return self._tranche.getnumpy(
+            self._name,
+            option,
+            **kwargs,
+        )
 
     def explain(self, option: str) -> dict:
         """

--- a/tranche/section.py
+++ b/tranche/section.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from configparser import SectionProxy
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -46,8 +46,9 @@ class Section:
     def getlist(
         self,
         option: str,
+        dtype: Callable[[str], T] = str,  # type: ignore[assignment]
         **kwargs: Any,
-    ) -> Any:
+    ) -> list[T] | None:
         """
         Get an option value parsed as a list.
 
@@ -55,21 +56,27 @@ class Section:
         ----------
         option : str
             Option name within this section.
+
+        dtype : Callable[[str], T], optional
+            Converter applied to each item. Defaults to ``str``.
+
         **kwargs : Any
             Additional keyword arguments forwarded to
             :meth:`tranche.Tranche.getlist`.
 
         Returns
         -------
-        Any
-            Parsed list value as returned by
-            :meth:`tranche.Tranche.getlist`.
+        list of T
+            Parsed list with elements converted by ``dtype``.
         """
-        return self._tranche.getlist(self._name, option, **kwargs)
+        return self._tranche.getlist(self._name, option, dtype=dtype, **kwargs)
 
     def getexpression(
         self,
         option: str,
+        dtype: type | None = None,
+        backend: str | None = None,
+        allow_numpy: bool = False,
         **kwargs: Any,
     ) -> Any:
         """
@@ -79,6 +86,12 @@ class Section:
         ----------
         option : str
             Option name within this section.
+        backend : {"literal", "safe"} or None, optional
+            Evaluation backend. ``None`` chooses ``"safe"`` when
+            ``allow_numpy`` is True, otherwise ``"literal"``.
+        allow_numpy : bool, optional
+            If True and using the "safe" backend, expose limited numpy
+            functions under ``np``/``numpy``.
         **kwargs : Any
             Additional keyword arguments forwarded to
             :meth:`tranche.Tranche.getexpression`.
@@ -91,12 +104,17 @@ class Section:
         return self._tranche.getexpression(
             self._name,
             option,
+            dtype=dtype,
+            backend=backend,
+            allow_numpy=allow_numpy,
             **kwargs,
         )
 
     def getnumpy(
         self,
         option: str,
+        dtype: type | None = None,
+        backend: str | None = None,
         **kwargs: Any,
     ) -> Any:
         """
@@ -108,6 +126,10 @@ class Section:
         ----------
         option : str
             Option name within this section.
+        dtype : type, optional
+            If provided, cast list/tuple elements or dict values.
+        backend : {"literal", "safe"} or None, optional
+            Backend override. ``None`` chooses ``"safe"``.
         **kwargs : Any
             Additional keyword arguments forwarded to
             :meth:`tranche.Tranche.getnumpy`.
@@ -120,6 +142,8 @@ class Section:
         return self._tranche.getnumpy(
             self._name,
             option,
+            dtype=dtype,
+            backend=backend,
             **kwargs,
         )
 

--- a/tranche/tranche.py
+++ b/tranche/tranche.py
@@ -477,8 +477,8 @@ class Tranche:
             The value of the config option parsed into a list.
         """
 
-        # At this point, fallback is either None or a string; delegate
-        # retrieval to ConfigParser via get().
+        # At this point, fallback is either None or a list. If the option is missing,
+        # and fallback is provided, return the fallback list directly without parsing.
         raw = self.get(section, option, fallback=None, **kwargs)
         if raw is None:
             return fallback


### PR DESCRIPTION
This pull request adds support for fallback values and forwards keyword arguments in all Tranche config option getters, both at the top-level and section level. This improves flexibility and compatibility with `configparser` by allowing callers to specify fallback values and additional options, and ensures that section helpers (`getlist`, `getexpression`, `getnumpy`) properly forward these arguments. Comprehensive tests are included to verify fallback handling and correct behavior when options are present or missing.

### API enhancements for fallback and kwargs support

* All top-level Tranche getters (`get`, `getint`, `getfloat`, `getboolean`, `getlist`, `getexpression`, `getnumpy`) now accept `fallback` and arbitrary keyword arguments, forwarding them to the underlying `configparser` methods. This allows callers to specify default values and additional options for config retrieval. [[1]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8L299-R299) [[2]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8L428-R452) [[3]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8R496-R497) [[4]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8R573-R574)
* Section-level helpers in `tranche/section.py` (`getlist`, `getexpression`, `getnumpy`) are refactored to accept and forward arbitrary keyword arguments, ensuring consistent support for fallbacks and extra options. [[1]](diffhunk://#diff-c400d661a6d6bffb7c6d57aa3fbb1d3b676ceb0526c8804fe83b28789abd0a49L49-R73) [[2]](diffhunk://#diff-c400d661a6d6bffb7c6d57aa3fbb1d3b676ceb0526c8804fe83b28789abd0a49L84-R84) [[3]](diffhunk://#diff-c400d661a6d6bffb7c6d57aa3fbb1d3b676ceb0526c8804fe83b28789abd0a49L101-R100) [[4]](diffhunk://#diff-c400d661a6d6bffb7c6d57aa3fbb1d3b676ceb0526c8804fe83b28789abd0a49L121-R124)

### Improved fallback handling logic

* If an option is missing, the fallback value is returned directly for all relevant getters, including support for pre-parsed iterables and already-evaluated expressions. When an option is present, the fallback is ignored and the config value is used. [[1]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8L441-R484) [[2]](diffhunk://#diff-7b7c77956257918a172cfb4f6b74f91d235922bc20cecc21cc0f22cace9961e8R527-R538) [[3]](diffhunk://#diff-3d10d369e491890d8208bf396aecb1958b29af1dc9c8f7059307098439938025R192-R287)

### Testing and validation

* Added comprehensive tests to verify fallback behavior for all supported getters, including cases where options are missing, present, and with various fallback types. Section helpers are also tested for correct forwarding of kwargs.

### Type safety improvements

* Explicit type casting is used where necessary to help type checkers (e.g., mypy), especially in cases where `configparser` methods may return `None`.

### Minor codebase cleanups

* Unused imports removed and docstrings updated to reflect new keyword argument and fallback support. [[1]](diffhunk://#diff-c400d661a6d6bffb7c6d57aa3fbb1d3b676ceb0526c8804fe83b28789abd0a49L3-R5) [[2]](diffhunk://#diff-c400d661a6d6bffb7c6d57aa3fbb1d3b676ceb0526c8804fe83b28789abd0a49L84-R84) [[3]](diffhunk://#diff-c400d661a6d6bffb7c6d57aa3fbb1d3b676ceb0526c8804fe83b28789abd0a49L121-R124)

These changes make the Tranche config API more robust, flexible, and user-friendly.