### PR TITLE
Improve compatibility with ConfigParser and SectionProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+### Added
+- Broader `configparser.ConfigParser` compatibility so tranche can be used as a
+  more complete drop-in wrapper:
+  - Query methods: `sections()`, `options()`, `items()`, `defaults()`,
+    `keys()`, `values()`.
+  - Container protocol: `__contains__`, `__iter__`, `__len__`.
+  - In-memory loaders: `read_string()`, `read_file()`, `read_dict()` (with
+    provenance source labels and env-var interpolation for text loaders).
+  - Mutation: `add_section()`, `remove_option()`, `remove_section()`, plus
+    mapping assignment/deletion via `config[section] = {...}` and
+    `del config[section]`.  `remove_option`/`remove_section` act across all
+    layers so options truly disappear from the combined view.
+- `Section` is now a more complete `configparser.SectionProxy` wrapper:
+  `keys()`, `values()`, `items()`, `setdefault()`, `update()`, `pop()`,
+  `popitem()`, `clear()`, item assignment/deletion, and a `name` property.
+  Mutations are routed through the parent `Tranche` so they persist across
+  recombination.
+
+### Changed
+- `Section` now re-derives a live `SectionProxy` on each access instead of
+  caching one, so a held `Section` reflects later mutations rather than a stale
+  snapshot.
+
 ## [0.2.2] - 2025-09-22
 ### Changed
 - Internal maintenance release: bumped version metadata and prepared packaging.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,56 @@ lower = Tranche(); lower.add_from_file('base.cfg')
 lower.append(higher)  # entries from 'higher' win
 ```
 
+## ConfigParser-style access
+
+`Tranche` mirrors much of the `configparser.ConfigParser` interface, so code
+written against `ConfigParser` mostly works unchanged while still getting
+tranche's layering, provenance and comment handling:
+
+```python
+cfg.sections()                 # ['section', ...]
+cfg.options('section')         # ['option', ...]
+cfg.items('section')           # [('option', 'value'), ...]
+'section' in cfg               # membership test
+for name in cfg: ...           # iterate section names
+len(cfg)                       # number of sections (counts DEFAULT)
+```
+
+You can also load configuration from memory rather than a file. Each loader
+takes a `source` label used for provenance and a `user` flag to mark user
+overrides:
+
+```python
+cfg.read_string('[section]\noption = value\n', source='<inline>')
+cfg.read_dict({'section': {'option': 'value'}})
+with open('extra.cfg') as f:
+    cfg.read_file(f)
+```
+
+Mutation is supported too. `remove_option` and `remove_section` act across
+*all* layers, so the option truly disappears from the combined view:
+
+```python
+cfg.add_section('new')
+cfg.remove_option('section', 'option')
+cfg.remove_section('old')
+
+cfg['section'] = {'option': 'value'}   # replace a whole section
+del cfg['section']
+```
+
+Sections behave like mutable mappings, with changes routed back through the
+parent `Tranche` so they persist across recombination:
+
+```python
+sec = cfg['section']
+sec['option'] = 'value'                # set a single option
+sec.update({'a': 1, 'b': 2})
+value = sec.setdefault('option', 'fallback')
+sec.pop('a')
+del sec['b']
+```
+
 ## Safe expressions
 
 To parse list/tuple/dict values, or evaluate expressions:

--- a/tests/test_tranche_compat.py
+++ b/tests/test_tranche_compat.py
@@ -1,0 +1,190 @@
+"""Tests for ConfigParser-compatibility additions to Tranche and Section."""
+
+import io
+import textwrap
+from configparser import DuplicateSectionError, NoSectionError
+from pathlib import Path
+
+import pytest
+
+from tranche.section import Section
+from tranche.tranche import Tranche
+
+
+def make_config() -> Tranche:
+    cfg = Tranche()
+    cfg.read_string(
+        textwrap.dedent(
+            """
+            [alpha]
+            x = 1
+            y = 2
+
+            [beta]
+            z = 3
+            """
+        ).lstrip(),
+        source="base.cfg",
+    )
+    return cfg
+
+
+# ---- Read loaders ---------------------------------------------------------
+
+
+def test_read_string_with_env_interpolation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRANCHE_TEST_VAR", "hello")
+    cfg = Tranche()
+    cfg.read_string("[s]\nv = ${env:TRANCHE_TEST_VAR}\n")
+    assert cfg.get("s", "v") == "hello"
+
+
+def test_read_dict_and_precedence() -> None:
+    cfg = Tranche()
+    cfg.read_dict({"main": {"a": 1, "b": 2}})
+    cfg.read_dict({"main": {"a": 99}}, source="<override>", user=True)
+    assert cfg.get("main", "a") == "99"
+    assert cfg.getint("main", "b") == 2
+
+
+def test_read_file_uses_stream_name(tmp_path: Path) -> None:
+    cfg = Tranche()
+    stream = io.StringIO("[s]\nv = 5\n")
+    cfg.read_file(stream, source="mem.cfg")
+    assert cfg.get("s", "v") == "5"
+    assert cfg.explain("s", "v")["source"] == "mem.cfg"
+
+
+# ---- Query methods --------------------------------------------------------
+
+
+def test_sections_options_items() -> None:
+    cfg = make_config()
+    assert cfg.sections() == ["alpha", "beta"]
+    assert cfg.options("alpha") == ["x", "y"]
+    assert cfg.items("alpha") == [("x", "1"), ("y", "2")]
+
+    all_items = cfg.items()
+    names = [name for name, _ in all_items]
+    assert names == ["alpha", "beta"]
+    assert all(isinstance(sec, Section) for _, sec in all_items)
+
+
+def test_keys_values_defaults() -> None:
+    cfg = make_config()
+    assert cfg.keys() == ["DEFAULT", "alpha", "beta"]
+    assert [s.name for s in cfg.values()] == ["DEFAULT", "alpha", "beta"]
+    assert dict(cfg.defaults()) == {}
+
+
+# ---- Container protocol ---------------------------------------------------
+
+
+def test_contains_iter_len() -> None:
+    cfg = make_config()
+    assert "alpha" in cfg
+    assert "missing" not in cfg
+    assert list(iter(cfg)) == ["DEFAULT", "alpha", "beta"]
+    # DEFAULT is counted by ConfigParser, so two sections -> len 3
+    assert len(cfg) == 3
+
+
+# ---- Mutation: add/remove across layers -----------------------------------
+
+
+def test_add_section_and_duplicate() -> None:
+    cfg = make_config()
+    cfg.add_section("gamma")
+    assert "gamma" in cfg.sections()
+    with pytest.raises(DuplicateSectionError):
+        cfg.add_section("gamma")
+
+
+def test_remove_option_across_layers() -> None:
+    cfg = make_config()
+    # user layer also defines alpha.x
+    cfg.read_dict({"alpha": {"x": 100}}, source="<user>", user=True)
+    assert cfg.get("alpha", "x") == "100"
+    assert cfg.remove_option("alpha", "x") is True
+    # removed from every layer, so it is gone entirely
+    assert not cfg.has_option("alpha", "x")
+    assert cfg.remove_option("alpha", "x") is False
+
+
+def test_remove_option_missing_section_raises() -> None:
+    cfg = make_config()
+    with pytest.raises(NoSectionError):
+        cfg.remove_option("nope", "x")
+
+
+def test_remove_section_returns_bool_and_clears_comments() -> None:
+    cfg = make_config()
+    assert cfg.remove_section("beta") is True
+    assert "beta" not in cfg.sections()
+    assert cfg.remove_section("beta") is False
+    # surviving section is unaffected
+    assert cfg.get("alpha", "x") == "1"
+
+
+# ---- Mapping mutation -----------------------------------------------------
+
+
+def test_setitem_replaces_section() -> None:
+    cfg = make_config()
+    cfg["alpha"] = {"only": "kept"}
+    assert cfg.options("alpha") == ["only"]
+    assert cfg.get("alpha", "only") == "kept"
+
+
+def test_delitem_section() -> None:
+    cfg = make_config()
+    del cfg["beta"]
+    assert "beta" not in cfg
+    with pytest.raises(KeyError):
+        del cfg["beta"]
+
+
+def test_section_setitem_survives_recombination() -> None:
+    cfg = make_config()
+    section = cfg["alpha"]
+    section["new"] = "val"
+    # mutate the parent so the combined config is rebuilt
+    cfg.remove_section("beta")
+    # the cached Section must still see the new value (live proxy)
+    assert section["new"] == "val"
+    assert cfg.get("alpha", "new") == "val"
+
+
+def test_section_mapping_mutators() -> None:
+    cfg = make_config()
+    section = cfg["alpha"]
+
+    assert section.setdefault("x") == "1"
+    assert section.setdefault("brand", "new") == "new"
+    assert cfg.get("alpha", "brand") == "new"
+
+    section.update({"p": 1}, q=2)
+    assert cfg.get("alpha", "p") == "1"
+    assert cfg.get("alpha", "q") == "2"
+
+    assert section.pop("p") == "1"
+    assert section.pop("absent", "fallback") == "fallback"
+    with pytest.raises(KeyError):
+        section.pop("absent")
+
+    option, _ = section.popitem()
+    assert option not in cfg.options("alpha")
+
+    section.clear()
+    assert cfg.options("alpha") == []
+
+
+def test_section_keys_values_items() -> None:
+    cfg = make_config()
+    section = cfg["alpha"]
+    assert list(section.keys()) == ["x", "y"]
+    assert list(section.values()) == ["1", "2"]
+    assert list(section.items()) == [("x", "1"), ("y", "2")]
+    assert section.name == "alpha"

--- a/tranche/section.py
+++ b/tranche/section.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, ItemsView, Iterator, KeysView, ValuesView
 from configparser import SectionProxy
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -9,6 +9,9 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
     from .tranche import Tranche
 
 T = TypeVar("T")
+
+# Sentinel distinguishing "argument not provided" from an explicit ``None``.
+_UNSET: Any = object()
 
 
 class Section:
@@ -33,13 +36,27 @@ class Section:
         tranche : Tranche
             Parent configuration object providing helper methods.
         proxy : configparser.SectionProxy
-            Underlying section proxy to delegate standard behavior to.
+            Underlying section proxy (unused except as a hint; a live proxy is
+            re-derived on each access so the wrapper never goes stale after the
+            combined config is rebuilt).
         name : str
             Name of the section represented by this wrapper.
         """
         self._tranche = tranche
-        self._proxy = proxy
         self._name = name
+
+    @property
+    def _proxy(self) -> SectionProxy:
+        """The live ``SectionProxy`` from the parent's combined config.
+
+        Re-derived on each access so the wrapper reflects mutations to the
+        underlying :class:`Tranche` rather than a stale snapshot.
+        """
+        if self._tranche.combined is None:
+            self._tranche.combine()
+        combined = self._tranche.combined
+        assert combined is not None  # for type checkers; combine() set it
+        return combined[self._name]
 
     # ---- Convenience getters backed by Tranche methods ----
 
@@ -182,10 +199,30 @@ class Section:
         """
         return self._tranche.has_option(self._name, option)
 
+    @property
+    def name(self) -> str:
+        """The name of this section."""
+        return self._name
+
     # ---- Mapping-like behavior and delegation ----
 
     def __getitem__(self, option: str) -> str:  # keep parity with SectionProxy
         return self._proxy[option]
+
+    def __setitem__(self, option: str, value: Any) -> None:
+        """
+        Set a single option in this section via the parent :class:`Tranche`.
+
+        The value is stored in tranche's runtime layer so that it survives
+        recombination, unlike assigning directly to the underlying
+        ``SectionProxy``.  Other layers and their provenance are left intact.
+        """
+        self._tranche._set_runtime(self._name, option, value)
+
+    def __delitem__(self, option: str) -> None:
+        """Remove an option from this section across all layers."""
+        if not self._tranche.remove_option(self._name, option):
+            raise KeyError(option)
 
     def __contains__(self, option: object) -> bool:
         return option in self._proxy
@@ -195,6 +232,114 @@ class Section:
 
     def __len__(self) -> int:
         return len(self._proxy)
+
+    def keys(self) -> KeysView[str]:
+        """The option names in this section."""
+        return self._proxy.keys()
+
+    def values(self) -> ValuesView[str]:
+        """The option values in this section."""
+        return self._proxy.values()
+
+    def items(self) -> ItemsView[str, str]:
+        """The ``(option, value)`` pairs in this section."""
+        return self._proxy.items()
+
+    # ---- Mapping mutation routed through the parent Tranche ----
+    #
+    # ``SectionProxy`` is a ``MutableMapping``; its mixin mutators (``pop``,
+    # ``popitem``, ``clear``, ``setdefault``, ``update``) would otherwise edit
+    # the transient combined parser and be lost on the next ``combine()``.  We
+    # override them to mutate tranche's layers so changes persist.
+
+    def setdefault(self, option: str, value: Any = "") -> str:
+        """
+        Return ``option``'s value, setting it to ``value`` first if absent.
+
+        Parameters
+        ----------
+        option : str
+            Option name within this section.
+        value : Any, optional
+            Value to set (and return) if the option does not yet exist.
+
+        Returns
+        -------
+        str
+            The existing or newly set value.
+        """
+        if self._tranche.has_option(self._name, option):
+            return self._proxy[option]
+        self._tranche._set_runtime(self._name, option, value)
+        return str(value)
+
+    def update(
+        self,
+        other: Any = (),
+        /,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Update options from a mapping or iterable of pairs and/or keywords.
+
+        Mirrors ``dict.update``; each value is stored in tranche's runtime
+        layer.
+        """
+        if hasattr(other, "keys"):
+            for option in other.keys():
+                self._tranche._set_runtime(self._name, option, other[option])
+        else:
+            for option, value in other:
+                self._tranche._set_runtime(self._name, option, value)
+        for option, value in kwargs.items():
+            self._tranche._set_runtime(self._name, option, value)
+
+    def pop(self, option: str, default: Any = _UNSET) -> Any:
+        """
+        Remove ``option`` and return its value across all layers.
+
+        Parameters
+        ----------
+        option : str
+            Option name within this section.
+        default : Any, optional
+            Value to return if the option is absent.  If omitted, a
+            ``KeyError`` is raised for a missing option.
+
+        Returns
+        -------
+        Any
+            The removed value, or ``default`` if the option was absent.
+        """
+        if not self._tranche.has_option(self._name, option):
+            if default is _UNSET:
+                raise KeyError(option)
+            return default
+        value = self._proxy[option]
+        self._tranche.remove_option(self._name, option)
+        return value
+
+    def popitem(self) -> tuple[str, str]:
+        """
+        Remove and return an arbitrary ``(option, value)`` pair.
+
+        Raises
+        ------
+        KeyError
+            If the section has no options.
+        """
+        options = self._tranche.options(self._name)
+        if not options:
+            raise KeyError(f"section {self._name!r} is empty")
+        option = options[-1]
+        value = self._proxy[option]
+        self._tranche.remove_option(self._name, option)
+        return option, value
+
+    def clear(self) -> None:
+        """Remove all options from this section across all layers."""
+        for option in self._tranche.options(self._name):
+            self._tranche.remove_option(self._name, option)
 
     def __repr__(self) -> str:  # helpful debugging
         return f"Section(name={self._name!r}, proxy={self._proxy!r})"

--- a/tranche/tranche.py
+++ b/tranche/tranche.py
@@ -4,13 +4,15 @@ import math
 import os
 import re
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Mapping
 from configparser import (
     ConfigParser,
     ExtendedInterpolation,
+    NoSectionError,
     RawConfigParser,
 )
 from importlib.resources import files as imp_res_files
+from io import StringIO
 from re import Match
 from types import ModuleType
 from typing import Any, TextIO, TypeVar, cast
@@ -19,6 +21,9 @@ from .section import Section
 
 CombinedParser = ConfigParser | RawConfigParser
 T = TypeVar("T")
+
+# Sentinel distinguishing "argument not provided" from an explicit ``None``.
+_UNSET: Any = object()
 
 
 class Tranche:
@@ -295,6 +300,105 @@ class Tranche:
         except (ModuleNotFoundError, FileNotFoundError, TypeError):
             if exception:
                 raise
+
+    def read_string(
+        self,
+        string: str,
+        source: str = "<string>",
+        user: bool = False,
+    ) -> None:
+        """
+        Add config options read from a string.
+
+        This mirrors :meth:`configparser.ConfigParser.read_string` while
+        preserving comments, provenance and layered precedence.  Environment
+        variables of the form ``${env:VAR}`` are interpolated, just as for
+        :meth:`add_from_file`.
+
+        Parameters
+        ----------
+        string : str
+            The config contents to parse.
+
+        source : str, optional
+            A label used as the provenance "source" for these options.  A later
+            call with the same ``source`` replaces the earlier layer.
+
+        user : bool, optional
+            Whether these options should be treated as user overrides that take
+            precedence over all base options.
+        """
+        self._ingest(string.splitlines(keepends=True), source, user=user)
+
+    def read_file(
+        self,
+        f: Any,
+        source: str | None = None,
+        user: bool = False,
+    ) -> None:
+        """
+        Add config options read from an open file or iterable of lines.
+
+        This mirrors :meth:`configparser.ConfigParser.read_file` while
+        preserving comments, provenance and layered precedence.
+
+        Parameters
+        ----------
+        f : iterable of str
+            An open file object or any iterable yielding config lines.
+
+        source : str, optional
+            A label used as the provenance "source" for these options.  If not
+            given, ``f.name`` is used when available, otherwise ``"<stream>"``.
+            A later call with the same ``source`` replaces the earlier layer.
+
+        user : bool, optional
+            Whether these options should be treated as user overrides that take
+            precedence over all base options.
+        """
+        if source is None:
+            source = getattr(f, "name", "<stream>")
+        self._ingest(list(f), cast(str, source), user=user)
+
+    def read_dict(
+        self,
+        dictionary: Mapping[str, Mapping[str, Any]],
+        source: str = "<dict>",
+        user: bool = False,
+    ) -> None:
+        """
+        Add config options read from a nested dictionary.
+
+        This mirrors :meth:`configparser.ConfigParser.read_dict`.  Keys and
+        values are converted to strings.  Options added this way have empty
+        comments.
+
+        Parameters
+        ----------
+        dictionary : Mapping[str, Mapping[str, Any]]
+            A mapping of the form ``{section: {option: value, ...}, ...}``.
+
+        source : str, optional
+            A label used as the provenance "source" for these options.  If
+            several calls share a source, later options overwrite earlier ones.
+
+        user : bool, optional
+            Whether these options should be treated as user overrides that take
+            precedence over all base options.
+        """
+        config_dict = self._user_config if user else self._configs
+        config = config_dict.setdefault(source, RawConfigParser())
+        comments = self._comments.setdefault(source, {})
+        for section, options in dictionary.items():
+            section = str(section)
+            if not config.has_section(section):
+                config.add_section(section)
+            comments.setdefault(section, "")
+            for option, value in options.items():
+                option = str(option).lower()
+                config.set(section, option, str(value))
+                comments[(section, option)] = ""
+        self._invalidate()
 
     def get(self, section: str, option: str, **kwargs: Any) -> str | None:
         """
@@ -704,6 +808,136 @@ class Tranche:
         combined = cast(CombinedParser, self.combined)
         return combined.has_option(section, option)
 
+    def sections(self) -> list[str]:
+        """
+        Get the list of section names in the combined config.
+
+        The special ``[DEFAULT]`` section is not included, mirroring
+        :meth:`configparser.ConfigParser.sections`.
+
+        Returns
+        -------
+        sections : list of str
+            The names of the config sections
+        """
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        return combined.sections()
+
+    def options(self, section: str) -> list[str]:
+        """
+        Get the list of option names available in the given section.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        Returns
+        -------
+        options : list of str
+            The names of the options in the section
+        """
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        return combined.options(section)
+
+    def defaults(self) -> Mapping[str, str]:
+        """
+        Get the options in the special ``[DEFAULT]`` section.
+
+        Returns
+        -------
+        defaults : Mapping[str, str]
+            The fallback options applied to every section
+        """
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        return combined.defaults()
+
+    def items(
+        self,
+        section: str = _UNSET,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Get section or option items from the combined config.
+
+        Mirrors :meth:`configparser.ConfigParser.items`.
+
+        Parameters
+        ----------
+        section : str, optional
+            If given, return a list of ``(option, value)`` pairs for that
+            section.  If omitted, return a list of ``(name, section)`` pairs for
+            every section, where each ``section`` is a
+            :class:`tranche.section.Section` wrapper.
+
+        **kwargs : Any
+            Additional keyword arguments (e.g. ``raw``, ``vars``) forwarded to
+            :meth:`configparser.ConfigParser.items` when ``section`` is given.
+
+        Returns
+        -------
+        items : list
+            Either ``(name, Section)`` pairs or ``(option, value)`` pairs.
+        """
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        if section is _UNSET:
+            return [(name, self[name]) for name in combined.sections()]
+        return combined.items(section, **kwargs)
+
+    def keys(self) -> list[str]:
+        """
+        Get the section names in the combined config (including ``DEFAULT``).
+
+        Returns
+        -------
+        keys : list of str
+            The section names, mirroring mapping access via ``config[section]``
+        """
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        return list(combined.keys())
+
+    def values(self) -> list[Section]:
+        """
+        Get a :class:`tranche.section.Section` wrapper for each section.
+
+        Returns
+        -------
+        values : list of tranche.section.Section
+            The sections of the combined config
+        """
+        return [self[name] for name in self.keys()]
+
+    def __contains__(self, section: object) -> bool:
+        """Whether ``section`` is a section in the combined config."""
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        return section in combined
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the section names (including ``DEFAULT``)."""
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        return iter(combined)
+
+    def __len__(self) -> int:
+        """The number of sections (including ``DEFAULT``) in the config."""
+        if self.combined is None:
+            self.combine()
+        combined = cast(CombinedParser, self.combined)
+        return len(combined)
+
     def set(
         self,
         section: str,
@@ -749,16 +983,159 @@ class Tranche:
         if not config.has_section(section):
             config.add_section(section)
         config.set(section, option, value)
-        self.combined = None
-        self.combined_comments = None
-        self.sources = None
+        self._invalidate()
         if filename not in self._comments:
             self._comments[filename] = dict()
+        self._comments[filename].setdefault(section, '')
         if comment is None:
             comment = ''
         else:
             comment = ''.join([f'# {line}\n' for line in comment.split('\n')])
         self._comments[filename][(section, option)] = comment
+
+    def add_section(self, section: str, user: bool = False) -> None:
+        """
+        Add an empty section.  The file from which this function was called is
+        retained for provenance, mirroring :meth:`set`.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section to add
+
+        user : bool, optional
+            Whether this section was supplied by the user and should take
+            priority over other sources
+
+        Raises
+        ------
+        configparser.DuplicateSectionError
+            If the section already exists in the calling file's layer
+        """
+        calling_frame = inspect.stack(context=2)[1]
+        filename = os.path.abspath(calling_frame.filename)
+        config_dict = self._user_config if user else self._configs
+        if filename not in config_dict:
+            config_dict[filename] = RawConfigParser()
+        config_dict[filename].add_section(section)
+        self._comments.setdefault(filename, {}).setdefault(section, '')
+        self._invalidate()
+
+    def remove_option(self, section: str, option: str) -> bool:
+        """
+        Remove an option from a section across all layers.
+
+        The option is removed from every contributing file (both base and user
+        layers) so that it no longer appears in the combined config.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        Returns
+        -------
+        existed : bool
+            Whether the option existed in any layer before removal
+
+        Raises
+        ------
+        configparser.NoSectionError
+            If the section is not present in any layer
+        """
+        option = option.lower()
+        section_found = False
+        existed = False
+        for config_dict in (self._configs, self._user_config):
+            for source, config in config_dict.items():
+                if not config.has_section(section):
+                    continue
+                section_found = True
+                if config.remove_option(section, option):
+                    existed = True
+                    self._comments.get(source, {}).pop((section, option), None)
+        if not section_found:
+            raise NoSectionError(section)
+        if existed:
+            self._invalidate()
+        return existed
+
+    def remove_section(self, section: str) -> bool:
+        """
+        Remove a section and all of its options across all layers.
+
+        The section is removed from every contributing file (both base and user
+        layers) so that it no longer appears in the combined config.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        Returns
+        -------
+        existed : bool
+            Whether the section existed in any layer before removal
+        """
+        existed = False
+        for config_dict in (self._configs, self._user_config):
+            for source, config in config_dict.items():
+                if config.remove_section(section):
+                    existed = True
+                comments = self._comments.get(source)
+                if comments is None:
+                    continue
+                comments.pop(section, None)
+                for key in [
+                    key
+                    for key in comments
+                    if isinstance(key, tuple) and key[0] == section
+                ]:
+                    comments.pop(key, None)
+        if existed:
+            self._invalidate()
+        return existed
+
+    def __setitem__(self, section: str, options: Mapping[str, Any]) -> None:
+        """
+        Set the options of a section, replacing any existing section.
+
+        Mirrors ``ConfigParser.__setitem__``: the existing section (in every
+        layer) is removed first, then the provided options are added to a
+        runtime layer.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        options : Mapping[str, Any]
+            The options to set in the section
+        """
+        self.remove_section(section)
+        for option, value in dict(options).items():
+            self._set_runtime(section, option, value)
+
+    def __delitem__(self, section: str) -> None:
+        """
+        Remove a section across all layers.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        Raises
+        ------
+        KeyError
+            If the section does not exist
+        """
+        if section not in self:
+            raise KeyError(section)
+        self.remove_section(section)
 
     def write(
         self,
@@ -862,9 +1239,7 @@ class Tranche:
         self._configs.update(other._configs)
         self._user_config.update(other._user_config)
         self._comments.update(other._comments)
-        self.combined = None
-        self.combined_comments = None
-        self.sources = None
+        self._invalidate()
 
     def prepend(self, other: "Tranche") -> None:
         """
@@ -890,9 +1265,7 @@ class Tranche:
         comments = dict(other._comments)
         comments.update(self._comments)
         self._comments = comments
-        self.combined = None
-        self.combined_comments = None
-        self.sources = None
+        self._invalidate()
 
     def __getitem__(self, section: str) -> Section:
         """
@@ -990,24 +1363,54 @@ class Tranche:
 
     def _add(self, filename: str, user: bool) -> None:
         filename = os.path.abspath(filename)
-        config = RawConfigParser()
         if not os.path.exists(filename):
             raise FileNotFoundError(f'Config file does not exist: {filename}')
-        # Preprocess file for env var interpolation before reading
         with open(filename, encoding="utf-8") as f:
             lines = f.readlines()
-        lines = [self._interpolate_env_vars(line) for line in lines]
-        from io import StringIO
+        self._ingest(lines, filename, user=user)
 
-        config.read_file(StringIO(''.join(lines)), source=filename)
-        with open(filename, encoding="utf-8") as fp:
-            comments = self._parse_comments(fp, filename, comments_before=True)
+    def _ingest(self, lines: list[str], source: str, user: bool) -> None:
+        """
+        Parse ``lines`` of config text and store them under ``source``.
 
+        Shared by :meth:`_add`, :meth:`read_string` and :meth:`read_file`.
+        Environment variables (``${env:VAR}``) are interpolated and comments are
+        preserved.
+        """
+        interpolated = [self._interpolate_env_vars(line) for line in lines]
+        config = RawConfigParser()
+        config.read_file(StringIO(''.join(interpolated)), source=source)
+        # Parse comments from the original (un-interpolated) text
+        comments = self._parse_comments(
+            StringIO(''.join(lines)), source, comments_before=True
+        )
         if user:
-            self._user_config[filename] = config
+            self._user_config[source] = config
         else:
-            self._configs[filename] = config
-        self._comments[filename] = comments
+            self._configs[source] = config
+        self._comments[source] = comments
+        self._invalidate()
+
+    def _set_runtime(self, section: str, option: str, value: Any) -> None:
+        """
+        Set a single option in the shared in-memory ``<dict>`` base layer.
+
+        Used by mapping-style assignment (:meth:`__setitem__` and
+        ``Section.__setitem__``) where there is no originating file to attribute.
+        """
+        source = '<dict>'
+        config = self._configs.setdefault(source, RawConfigParser())
+        comments = self._comments.setdefault(source, {})
+        if not config.has_section(section):
+            config.add_section(section)
+            comments.setdefault(section, '')
+        option = option.lower()
+        config.set(section, option, str(value))
+        comments[(section, option)] = ''
+        self._invalidate()
+
+    def _invalidate(self) -> None:
+        """Reset cached combined state so it is rebuilt on next access."""
         self.combined = None
         self.combined_comments = None
         self.sources = None

--- a/tranche/version.py
+++ b/tranche/version.py
@@ -8,4 +8,4 @@ __all__ = ["__version__"]
 
 # Update this value for releases; pre-releases can use semantic versions
 # like "0.2.0rc1". The packaging config reads this attribute.
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
Add the commonly expected ConfigParser surface to Tranche so it can act as a more complete drop-in wrapper, while preserving comments, provenance and layered precedence:

- Query: sections(), options(), items(), defaults(), keys(), values()
- Container protocol: __contains__, __iter__, __len__
- In-memory loaders: read_string(), read_file(), read_dict()
- Mutation: add_section(), remove_option(), remove_section() and mapping
  assignment/deletion. remove_option/remove_section act across all layers
  so options disappear from the combined view.

Make Section a fuller SectionProxy wrapper (keys/values/items, setdefault, update, pop, popitem, clear, item assignment/deletion, name property), routing all mutation through the parent Tranche so it survives recombination. Section now re-derives a live proxy on each access rather than caching a snapshot that could go stale after a mutation.

Factor shared internals into _invalidate(), _ingest() and _set_runtime().

Updates to v0.5.0.